### PR TITLE
New: Deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 **This repo is now deprecated.**
 
-For changes, new features, hints, etc. please [use this link](https://github.com/webhintio/hint/issues/new)**
+For changes, new features, hints, etc. please [use this link](https://github.com/webhintio/hint/issues/new/choose)**
 
 🛑🛑🛑🛑🛑

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # rfcs
 
-Request for changes, new features, hints, etc. for webhint.
+🛑🛑🛑🛑🛑
+
+**This repo is now deprecated.**
+
+For changes, new features, hints, etc. please [use this link](https://github.com/webhintio/hint/issues/new)**
+
+🛑🛑🛑🛑🛑


### PR DESCRIPTION
Now that the main repo has issue templates with labels this repo doesn't make too much sense anymore.
What we need to do:

* [x] Move all issues to the hint repo (or reopen the old closed ones)
* [x] Add the deprecation message
* [ ] Archive repository
* [ ] Remove it from the short list of org repos 
